### PR TITLE
Fix bug with query including all nodes

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -27,8 +27,8 @@ agent_manager = "#{node['ossec']['user']['dir']}/bin/ossec-batch-manager.pl"
 ssh_hosts = Array.new
 
 search_string = "ossec:[* TO *]" 
-search_string << " AND chef_environment:#{node['ossec']['server_env']}" if node['ossec']['server_env']
-search_string << " NOT role:#{node['ossec']['server_role']}"
+search_string << " AND chef_environment:#{node['ossec']['server_env']} " if node['ossec']['server_env']
+search_string << " AND NOT role:#{node['ossec']['server_role']}"
 
 search(:node, search_string) do |n|
 


### PR DESCRIPTION
The missing AND before `NOT role:...` makes the first part of the search
query irrelevant because it is ORed. This breaks within Kitchen using
the Vagrant driver because it does not set ipaddress or fqdn
within /tmp/kitchen/nodes/*
