### PR TITLE
Fix untarring for OSSEC 2.8.2 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,11 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{ossec_dir}.tar.gz" do
   checksum node['ossec']['checksum']
 end
 
-execute "tar zxvf #{ossec_dir}.tar.gz" do
+directory "#{Chef::Config[:file_cache_path]}/#{ossec_dir}" do
+  action "create"
+end
+
+execute "tar zxvf #{ossec_dir}.tar.gz --strip-components=1 --directory #{ossec_dir}" do
   cwd Chef::Config[:file_cache_path]
   creates "#{Chef::Config[:file_cache_path]}/#{ossec_dir}"
 end


### PR DESCRIPTION
OSSEC 2.8.2 has the first level folder as 2.7. 
This fixes the issue by stripping the top level folder and extracting
to a folder named the same as the version string.
